### PR TITLE
Fixes issues reported by go vet and staticcheck

### DIFF
--- a/app/basic/put.go
+++ b/app/basic/put.go
@@ -54,7 +54,7 @@ func Action_Put(args *cli.Context) error {
 	//  FIXME: still just fixed placeholder content.  More needed here.
 	lnk, err := lsys.Store(
 		linking.LinkContext{Ctx: context.Background()},
-		cidlink.LinkPrototype{cid.Prefix{
+		cidlink.LinkPrototype{Prefix: cid.Prefix{
 			Version:  1,    // Usually '1'.
 			Codec:    0x71, // dag-cbor as per multicodec table.
 			MhType:   0x15, // please switch this to 0x20 as soon as go-multihash#149 is merged.

--- a/app/schema/schemalib.go
+++ b/app/schema/schemalib.go
@@ -7,7 +7,7 @@ import (
 	schemadmt "github.com/ipld/go-ipld-prime/schema/dmt"
 	schemadsl "github.com/ipld/go-ipld-prime/schema/dsl"
 
-	"github.com/ipld/go-ipldtool/errors"
+	ipldtoolerr "github.com/ipld/go-ipldtool/errors"
 )
 
 // DSLParse is just the `schemadsl.Parse` feature, but wrapped in error tagging.
@@ -20,10 +20,10 @@ func DSLParse(inputName string, input io.Reader) (*schemadmt.Schema, error) {
 	dmt, err := schemadsl.Parse(inputName, input)
 	if err != nil {
 		return nil, &ipldtoolerr.Error{
-			ErrCode_SchemaDSLParseFailed,
-			err.Error(),
-			nil,
-			err,
+			TheCode:    ErrCode_SchemaDSLParseFailed,
+			TheMessage: err.Error(),
+			TheDetails: nil,
+			TheCause:   err,
 		}
 	}
 	return dmt, nil
@@ -40,10 +40,10 @@ func SchemaCompile(dmt *schemadmt.Schema) (*schema.TypeSystem, error) {
 	ts.Init()
 	if err := schemadmt.Compile(&ts, dmt); err != nil {
 		return nil, &ipldtoolerr.Error{
-			ErrCode_SchemaCompileFailed,
-			err.Error(),
-			nil,
-			err,
+			TheCode:    ErrCode_SchemaCompileFailed,
+			TheMessage: err.Error(),
+			TheDetails: nil,
+			TheCause:   err,
 		}
 	}
 	return &ts, nil

--- a/app/workspace/workspaceCmd.go
+++ b/app/workspace/workspaceCmd.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -74,7 +73,7 @@ func Action_WorkspaceFind(args *cli.Context) error {
 	// Parse positional args.
 	switch args.Args().Len() {
 	case 0:
-		wspath, err := Find()
+		_, err := Find()
 		switch err.(*ipldtoolerr.Error).Code() {
 		case "":
 			return nil
@@ -83,8 +82,6 @@ func Action_WorkspaceFind(args *cli.Context) error {
 		default:
 			return err // (Wish: the error analysis tool could subtract the cases above from codes still possible in `err` here.)
 		}
-		fmt.Fprintf(args.App.Writer, "%s\n", wspath)
-		return nil
 	default:
 		// I flirted with the idea of accepting a positional arg for where to start the search from,
 		// but this seems like a bad idea; or if we do it, that should be a consistent arg for all commands globally.


### PR DESCRIPTION
I've found issues reported by `go vet` and `staticcheck` here: https://github.com/ipld/go-ipldtool/runs/4189436482?check_suite_focus=true

This PR fixes the following issues:
- `composite literal uses unkeyed fields`
- `unreachable code`

I have tested it by running `go vet ./...` and `staticcheck ./...`.

It should bring us one step closer to merging https://github.com/ipld/go-ipldtool/pull/2